### PR TITLE
only emulate a single keypress

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mod_version=1.0
+mod_version=1.1
 compatible_minecraft_versions=[1.8.9, 1.13)
 target_minecraft_version=1.12.2
 forge_version=14.23.5.2768

--- a/src/main/java/io/github/leo3418/mckeyboardfix/MCKeyboardFix.java
+++ b/src/main/java/io/github/leo3418/mckeyboardfix/MCKeyboardFix.java
@@ -65,25 +65,16 @@ public final class MCKeyboardFix {
          * `^` key, and Shift-2 is interpreted as a press on the `@` key, and
          * the numeric key is never detected as pressed in these cases. For
          * most keyboards, this does not make sense since they do not have
-         * dedicated `^` or `@` key, but indeed, this is what happens.
-         *
-         * To fix this issue, we just need to emulate a press on the numeric
-         * key. But merely doing this is not enough because after we emulate a
-         * press on key `x`, every key combination from Shift-1 to Shift-`x-1`
-         * does not work until the user presses the combination again, so we
-         * also need to emulate those presses to mitigate this side effect of
-         * the fix.
+         * dedicated `^` or `@` key, but indeed, this is what happens. To fix
+         * this issue, we just need to emulate a press on the numeric key.
          */
         switch (keyCode) {
-            case KEY_CIRCUMFLEX: // Shift-6
+            case KEY_CIRCUMFLEX: { // Shift-6
                 pressKey(KEY_6);
-                pressKey(KEY_5);
-                pressKey(KEY_4);
-                pressKey(KEY_3);
-                // Fall through
-            case KEY_AT: // Shift-2
+            } break;
+            case KEY_AT: { // Shift-2
                 pressKey(KEY_2);
-                pressKey(KEY_1);
+            } break;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/Leo3418/mckeyboardfix/issues/4

Alright so I did remove the comment text saying we must emulate every key below it- I can't reproduce any issue related to this. @Leo3418, can you give me specific steps? I have a feeling it's only going to be for some desktops. I am running KDE+Wayland on Arch.

Build with this patch (zip contains a single jar):
[mckeyboardfix.zip](https://github.com/Leo3418/mckeyboardfix/files/9177095/mckeyboardfix.zip)

You can check the code with this online decompiler http://www.javadecompilers.com/